### PR TITLE
support single links, resources as well as slices (including single slice)

### DIFF
--- a/hal.go
+++ b/hal.go
@@ -56,17 +56,12 @@ func (e Embedded) AddCollection(rel Relation, r ResourceCollection) {
 		return
 	}
 
-	nr, isExistingResource := n.(*Resource)
-	nc, isExistingCollection := n.([]*Resource)
-
-	if isExistingCollection {
-		//existing collection
+	if nc, ok := n.([]*Resource); ok {
 		e[rel] = append(nc, r...)
 		return
 	}
 
-	if isExistingResource {
-		//single resource - turn it into a collection
+	if nr, ok := n.(*Resource); ok {
 		e[rel] = append([]*Resource{nr}, r...)
 	}
 
@@ -83,26 +78,18 @@ func (e Embedded) Add(rel Relation, r *Resource) {
 		return
 	}
 
-	nee, isExistingResource := n.(*Resource)
-	nec, isExistingCollection := n.([]*Resource)
-
-	if isExistingCollection {
-		//existing collection
-		nec = append(nec, r)
-		e[rel] = nec
+	if nec, ok := n.([]*Resource); ok {
+		e[rel] = append(nec, r)
 		return
 	}
 
-	if isExistingResource {
-		//existing resource with same rel - turn it into a collection
-		resources := []*Resource{nee}
-		resources = append(resources, r)
-		e[rel] = resources
-	} else {
-		//something went wrong.. replace what is there with what is new
-		resources := []*Resource{r}
-		e[rel] = resources
+	if nee, ok := n.(*Resource); ok {
+		e[rel] = append([]*Resource{nee}, r)
+		return
 	}
+
+	//something went wrong.. replace what is there with what is new
+	e[rel] = []*Resource{r}
 }
 
 // Set sets the resource into the list of embedded
@@ -158,20 +145,15 @@ func (r *Resource) AddLinkCollection(rel Relation, l LinkCollection) {
 		return
 	}
 
-	nl, isExistingLink := n.(Link)
-	nc, isExistingCollection := n.(LinkCollection)
-
-	if isExistingCollection {
-		//existing collection
+	if nc, ok := n.(LinkCollection); ok {
 		r.Links[rel] = append(nc, l...)
 		return
 	}
 
-	if isExistingLink {
+	if nl, ok := n.(Link); ok {
 		//prepend existing link to collection
 		r.Links[rel] = append(LinkCollection{nl}, l...)
 	}
-
 }
 
 // AddLink appends a Link to the resource.
@@ -184,23 +166,18 @@ func (r *Resource) AddLink(rel Relation, l Link) {
 		return
 	}
 
-	nl, isExistingLink := n.(Link)
-	nc, isExistingCollection := n.(LinkCollection)
-
-	if isExistingCollection {
-		//existing collection
-		nc = append(nc, l)
-		r.Links[rel] = nc
+	if nc, ok := n.(LinkCollection); ok {
+		r.Links[rel] = append(nc, l)
 		return
 	}
 
-	if isExistingLink {
-		//existing link with same rel - turn it into a collection
+	if nl, ok := n.(Link); ok {
 		r.Links[rel] = append(LinkCollection{nl}, l)
-	} else {
-		//something went wrong.. replace what is there with what is new
-		r.Links[rel] = LinkCollection{l}
+		return
 	}
+
+	//something went wrong.. replace what is there with what is new
+	r.Links[rel] = LinkCollection{l}
 }
 
 // AddNewLink appends a new Link object based on

--- a/hal_test.go
+++ b/hal_test.go
@@ -9,8 +9,8 @@ type DummyStruct struct {
 	Name string
 }
 
-func (ds DummyStruct) Encode() map[string]interface{} {
-	return map[string]interface{}{
+func (ds DummyStruct) GetMap() Entry {
+	return Entry{
 		"name": ds.Name,
 	}
 }
@@ -24,7 +24,7 @@ func TestNewResource(t *testing.T) {
 		t.Errorf("No links added to the new resource")
 	}
 
-	if r.Links[0].Rel != "self" {
+	if r.Links["self"] == nil {
 		t.Errorf("No SELF link added to the new resource")
 	}
 
@@ -34,20 +34,21 @@ func TestNewResource(t *testing.T) {
 }
 
 func TestLinkMarshal(t *testing.T) {
-	l := Link{"self", "http://localhost/"}
+	l := make(Link)
+	l["href"] = "http://localhost/"
 
 	jl, err := json.Marshal(l)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 
-	if string(jl) != `{"self":{"href":"http://localhost/"}}` {
+	if string(jl) != `{"href":"http://localhost/"}` {
 		t.Errorf("Wrong Link struct: %s", jl)
 	}
 }
 
 func TestResourceMarshal(t *testing.T) {
-	expected := `{"_links":[{"self":{"href":"uri"}}],"name":"Dummy"}`
+	expected := `{"_links":{"self":{"href":"uri"}},"name":"Dummy"}`
 
 	ds := DummyStruct{"Dummy"}
 
@@ -60,5 +61,186 @@ func TestResourceMarshal(t *testing.T) {
 
 	if string(jr) != expected {
 		t.Errorf("Wrong Resource struct: %s\n- Given: %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+/* Test Links */
+func TestNewLink(t *testing.T) {
+	expected := `{"href":"bar","templated":"true"}`
+
+	l := NewLink("bar", LinkAttr{"templated": "true"})
+
+	jr, err := json.Marshal(l)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong link struct: %s\n- Given: %s\n- Expected: %s", l, jr, expected)
+	}
+}
+
+func TestAddNewLink(t *testing.T) {
+	expected := `{"_links":{"foo":{"href":"bar"},"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	r.AddNewLink("foo", "bar")
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given: %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestAddNewLinkTwice(t *testing.T) {
+	expected := `{"_links":{"foo":[{"href":"bar"},{"href":"bar2"}],"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	r.AddNewLink("foo", "bar")
+	r.AddNewLink("foo", "bar2")
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given:    %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestAddLinkCollection(t *testing.T) {
+	expected := `{"_links":{"foo":[{"href":"bar"},{"href":"bar2"}],"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	r.AddLinkCollection("foo", LinkCollection{NewLink("bar", nil), NewLink("bar2", nil)})
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given:    %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestAddLinkCollectionToLink(t *testing.T) {
+	expected := `{"_links":{"foo":[{"href":"baz"},{"href":"bar"},{"href":"bar2"}],"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	r.AddNewLink("foo", "baz")
+	r.AddLinkCollection("foo", LinkCollection{NewLink("bar", nil), NewLink("bar2", nil)})
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given:    %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+/* Test Embedded */
+func TestEmbed(t *testing.T) {
+	expected := `{"_embedded":{"foo":{"_links":{"self":{"href":"uri2"}},"name":"DummyEmbed"}},"_links":{"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+	ds2 := DummyStruct{"DummyEmbed"}
+
+	r := NewResource(ds, "uri")
+	r2 := NewResource(ds2, "uri2")
+	r.Embed("foo", r2)
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given: %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestEmbedTwice(t *testing.T) {
+	expected := `{"_embedded":{"foo":[{"_links":{"self":{"href":"uri2"}},"name":"DummyEmbed"},{"_links":{"self":{"href":"uri3"}},"name":"DummyEmbed2"}]},"_links":{"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+	ds2 := DummyStruct{"DummyEmbed"}
+	ds3 := DummyStruct{"DummyEmbed2"}
+
+	r := NewResource(ds, "uri")
+	r2 := NewResource(ds2, "uri2")
+	r3 := NewResource(ds3, "uri3")
+	r.Embed("foo", r2)
+	r.Embed("foo", r3)
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given:    %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestAddResourceCollection(t *testing.T) {
+	expected := `{"_embedded":{"foo":[{"_links":{"self":{"href":"uri2"}},"name":"DummyEmbed"},{"_links":{"self":{"href":"uri3"}},"name":"DummyEmbed2"}]},"_links":{"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+	ds2 := DummyStruct{"DummyEmbed"}
+	ds3 := DummyStruct{"DummyEmbed2"}
+
+	r := NewResource(ds, "uri")
+	r2 := NewResource(ds2, "uri2")
+	r3 := NewResource(ds3, "uri3")
+	r.EmbedCollection("foo", ResourceCollection{r2, r3})
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given:    %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestAddResourceCollectionToResource(t *testing.T) {
+	expected := `{"_embedded":{"foo":[{"_links":{"self":{"href":"uri2"}},"name":"DummyEmbed"},{"_links":{"self":{"href":"uri3"}},"name":"DummyEmbed2"},{"_links":{"self":{"href":"uri4"}},"name":"DummyEmbed3"}]},"_links":{"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+	ds2 := DummyStruct{"DummyEmbed"}
+	ds3 := DummyStruct{"DummyEmbed2"}
+	ds4 := DummyStruct{"DummyEmbed3"}
+
+	r := NewResource(ds, "uri")
+	r2 := NewResource(ds2, "uri2")
+	r3 := NewResource(ds3, "uri3")
+	r4 := NewResource(ds4, "uri4")
+	r.Embed("foo", r2)
+	r.EmbedCollection("foo", ResourceCollection{r3, r4})
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given:    %s\n- Expected: %s", r, jr, expected)
 	}
 }


### PR DESCRIPTION
:warning: I am fairly new to go :warning:


**note** I removed the Get method on the Embedded map because I didn't think it was a good move to ask the caller to type assert the result.  I also am not sure how important this method is?

This change would allow the following to work for **Links** and **Embedded** items:
#### if you add a single element slice - it will render as a single element slice in json
```go
np := hal.NewResource(p, p.getSelfLink())
np.AddLinkCollection("slicefoo", hal.LinkCollection{hal.NewLink("foobar", hal.LinkAttr{"templated":"true"})})
```
becomes
```json
{
  "_links": {
    "self": {
      "href": "/person/foo"
    },
    "slicefoo": [
      {
        "href": "foobar",
        "templated": "true"
      }
    ]
  },
  "stuff" : "here"
}
```
- - -
#### if you add a single element (not in a slice) - it will render as a single element (not a slice) in json
```go
np := hal.NewResource(p, p.getSelfLink())
np.AddLink("foo", hal.NewLink("foobar", hal.LinkAttr{"templated":"true"}))
```
becomes
```json
{
  "_links": {
    "self": {
      "href": "/person/foo"
    },
    "foo": {
      "href": "foobar",
      "templated": "true"
    }
  },
  "stuff" : "here"
}
````
- - -
#### if you add multiple single elements with the same rel - it will automatically become a slice containing them all
```go
np := hal.NewResource(p, p.getSelfLink())
np.AddLink("foo", hal.NewLink("foobar", hal.LinkAttr{"templated":"true"}))
np.AddLink("foo", hal.NewLink("foobar2", hal.LinkAttr{"templated":"true"}))
```
becomes
```json
{
  "_links": {
    "self": {
      "href": "/person/foo"
    },
    "foo": [
      {
        "href": "foobar",
        "templated": "true"
      },
      {
        "href": "foobar2",
        "templated": "true"
      }
    ]
  },
  "stuff": "here"
}
```
- - -
#### if you add a single element or a slice to a rel that already contains a slice - it/they will be appended
```go
np := hal.NewResource(p, p.getSelfLink())
np.AddLinkCollection("slicefoo", hal.LinkCollection{hal.NewLink("foobar", hal.LinkAttr{"templated":"true"})})
np.AddLink("slicefoo", hal.NewLink("foobar2", hal.LinkAttr{"templated":"true"}))
```
becomes
```json
{
  "_links": {
    "self": {
      "href": "/person/foo"
    },
    "slicefoo": [
      {
        "href": "foobar",
        "templated": "true"
      },
      {
        "href": "foobar2",
        "templated": "true"
      }
    ]
  },
  "stuff" : "here"
}
```

**note: I have only demonstrated links but embedded resources work exactly the same.**