### PR TITLE
Allow any type as link value (not just strings)

### DIFF
--- a/hal.go
+++ b/hal.go
@@ -27,7 +27,7 @@ type (
 	Relation string
 
 	// Link types that store hyperlinks and its attributes.
-	LinkAttr       map[string]string
+	LinkAttr       map[string]interface{}
 	Link           LinkAttr
 	LinkCollection []Link
 	LinkRelations  map[Relation]interface{}

--- a/hal_test.go
+++ b/hal_test.go
@@ -87,9 +87,9 @@ func TestResourceMarshallWithMapper(t *testing.T) {
 
 /* Test Links */
 func TestNewLink(t *testing.T) {
-	expected := `{"href":"bar","templated":"true"}`
+	expected := `{"href":"bar","templated":true}`
 
-	l := NewLink("bar", LinkAttr{"templated": "true"})
+	l := NewLink("bar", LinkAttr{"templated": true})
 
 	jr, err := json.Marshal(l)
 	if err != nil {


### PR DESCRIPTION
The HAL specification use the "templated" attribute for link objects to
indicate that the link has a href in template form. This attribute
should have bool type. To allow this, change LinkAttr to be a map from
string to any value (instead of just strings). Fixes #8.