### PR TITLE
Add Curies Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Output
 		        "href":"http://acme.com/docs/{rel}",
 		        "templated":true
 		    }],
-		"acme:widgets": { "href: "http://rest.api/products/1/widgets" }
+		"acme:widgets": { "href": "http://rest.api/products/1/widgets" }
 	},
 	"name": "Some product",
 	"price": 10

--- a/README.md
+++ b/README.md
@@ -151,8 +151,56 @@ Output:
 }
 ```
 
+CURIES
+------
+To include CURIE relations in your output you can 'register' the curie name and fluently add a link relation as follows:
+
+```go
+p := Product{
+	Code: 1,
+	Name: "Some Product",
+	Price: 10
+}
+
+// Creating Product resource
+pr := hal.NewResource(p, "http://rest.api/products/1")
+pr.RegisterCurie("acme", "http://acme.com/docs/{rel}", true).AddNewLink("widgets", "http://rest.api/products/1/widgets")
+```
+
+Output
+
+```json
+{
+	"_links": {
+		"self": {"href": "http://rest.api/products/1"},
+		"curies:" [
+		    { 
+		        "name":"acme",
+		        "href":"http://acme.com/docs/{rel}",
+		        "templated":true
+		    }
+		],
+		"acme:widgets": { "href: "http://rest.api/products/1/widgets" }
+	},
+	"name": "Some product",
+	"price": 10
+}
+```
+
+Registered curies can also be retreived by name from the resources' Curies map:
+
+
+```go
+pr := hal.NewResource(p, "http://rest.api/products/1")
+pr.RegisterCurie("acme", "http://acme.com/docs/{rel}", true)
+...
+
+curie := pr.Curies["acme"]
+curie.AddNewLink("widgets", "http://rest.api/products/1/widgets")
+```
+
+
 Todo
 ----
 
- * CURIEs support.
  * XML Marshaler.

--- a/README.md
+++ b/README.md
@@ -173,13 +173,11 @@ Output
 {
 	"_links": {
 		"self": {"href": "http://rest.api/products/1"},
-		"curies:" [
-		    { 
+		"curies": [{ 
 		        "name":"acme",
 		        "href":"http://acme.com/docs/{rel}",
 		        "templated":true
-		    }
-		],
+		    }],
 		"acme:widgets": { "href: "http://rest.api/products/1/widgets" }
 	},
 	"name": "Some product",

--- a/hal.go
+++ b/hal.go
@@ -204,8 +204,10 @@ func (r *Resource) AddNewLink(rel Relation, href string) {
 // RegisterCurie adds a Link relation of type 'curies' and returns a CurieHandle
 // to allow users to chain adding new links that have this curie relation definition
 func (r *Resource) RegisterCurie(name, href string, templated bool) *CurieHandle {
-	l := NewLink(href, LinkAttr{"name": name}, LinkAttr{"templated": templated})
-	r.AddLink("curies", l)
+	l := LinkCollection{
+		NewLink(href, LinkAttr{"name": name}, LinkAttr{"templated": templated}),
+	}
+	r.AddLinkCollection("curies", l)
 
 	handle := &CurieHandle{Name: name, Resource: r}
 	r.Curies = append(r.Curies, handle)

--- a/hal.go
+++ b/hal.go
@@ -206,7 +206,7 @@ func (r *Resource) AddNewLink(rel Relation, href string) {
 func (r *Resource) RegisterCurie(name, href string, templated bool) *CurieHandle {
 	l := NewLink(href, LinkAttr{"name": name}, LinkAttr{"templated": templated})
 	r.AddLink("curies", l)
-	//r.Curies = append(r.Curies, l)
+
 	handle := &CurieHandle{Name: name, Resource: r}
 	r.Curies = append(r.Curies, handle)
 	return handle

--- a/hal.go
+++ b/hal.go
@@ -45,7 +45,7 @@ type (
 		Payload  interface{}
 		Links    LinkRelations
 		Embedded Embedded
-		Curies   []*CurieHandle
+		Curies   map[string]*CurieHandle
 	}
 	ResourceCollection []*Resource
 
@@ -145,7 +145,7 @@ func NewResource(p interface{}, selfUri string) *Resource {
 	r.AddNewLink("self", selfUri)
 
 	r.Embedded = make(Embedded)
-	r.Curies = make([]*CurieHandle, 0)
+	r.Curies = make(map[string]*CurieHandle)
 
 	return &r
 }
@@ -202,7 +202,7 @@ func (r *Resource) AddNewLink(rel Relation, href string) {
 }
 
 // RegisterCurie adds a Link relation of type 'curies' and returns a CurieHandle
-// to allow users to chain adding new links that have this curie relation definition
+// to allow users to fluently add new links that have this curie relation definition
 func (r *Resource) RegisterCurie(name, href string, templated bool) *CurieHandle {
 	l := LinkCollection{
 		NewLink(href, LinkAttr{"name": name}, LinkAttr{"templated": templated}),
@@ -210,7 +210,8 @@ func (r *Resource) RegisterCurie(name, href string, templated bool) *CurieHandle
 	r.AddLinkCollection("curies", l)
 
 	handle := &CurieHandle{Name: name, Resource: r}
-	r.Curies = append(r.Curies, handle)
+
+	r.Curies[name] = handle
 	return handle
 }
 

--- a/hal.go
+++ b/hal.go
@@ -26,6 +26,11 @@ type (
 
 	Relation string
 
+	CurieHandle struct {
+		Name string
+		*Resource
+	}
+
 	// Link types that store hyperlinks and its attributes.
 	LinkAttr       map[string]interface{}
 	Link           LinkAttr
@@ -40,11 +45,19 @@ type (
 		Payload  interface{}
 		Links    LinkRelations
 		Embedded Embedded
+		Curies   []*CurieHandle
 	}
 	ResourceCollection []*Resource
 
 	Embedded map[Relation]interface{}
 )
+
+// AddNewLink adds a link to the resources_link collection
+// prepended with the curie Name
+func (c CurieHandle) AddNewLink(rel Relation, href string) {
+	rel = Relation(c.Name) + ":" + rel
+	c.Resource.AddLink(rel, NewLink(href, nil))
+}
 
 // AddCollection appends the resource into the list of embedded
 // resources with the specified relation.
@@ -132,6 +145,7 @@ func NewResource(p interface{}, selfUri string) *Resource {
 	r.AddNewLink("self", selfUri)
 
 	r.Embedded = make(Embedded)
+	r.Curies = make([]*CurieHandle, 0)
 
 	return &r
 }
@@ -185,6 +199,17 @@ func (r *Resource) AddLink(rel Relation, l Link) {
 // the rel and href params.
 func (r *Resource) AddNewLink(rel Relation, href string) {
 	r.AddLink(rel, NewLink(href, nil))
+}
+
+// RegisterCurie adds a Link relation of type 'curies' and returns a CurieHandle
+// to allow users to chain adding new links that have this curie relation definition
+func (r *Resource) RegisterCurie(name, href string, templated bool) *CurieHandle {
+	l := NewLink(href, LinkAttr{"name": name}, LinkAttr{"templated": templated})
+	r.AddLink("curies", l)
+	//r.Curies = append(r.Curies, l)
+	handle := &CurieHandle{Name: name, Resource: r}
+	r.Curies = append(r.Curies, handle)
+	return handle
 }
 
 // Embed appends a Resource to the array of
@@ -257,13 +282,15 @@ func (r Resource) MarshalJSON() ([]byte, error) {
 }
 
 // NewLink returns a new Link object.
-func NewLink(href string, attr LinkAttr) Link {
+func NewLink(href string, attrs ...LinkAttr) Link {
 	l := make(Link)
 
 	l["href"] = href
 
-	for k, v := range attr {
-		l[k] = v
+	for _, attr := range attrs {
+		for k, v := range attr {
+			l[k] = v
+		}
 	}
 
 	return l

--- a/hal_test.go
+++ b/hal_test.go
@@ -117,12 +117,31 @@ func TestNewLinkMultipleAttributes(t *testing.T) {
 }
 
 func TestRegisterCurie(t *testing.T) {
-	expected := `{"_links":{"curies":{"href":"http://haltalk.herokuapp.com/docs/{rel}","name":"doc","templated":true},"doc:foo":{"href":"bar"},"self":{"href":"uri"}},"name":"Dummy"}`
+	expected := `{"_links":{"curies":[{"href":"http://haltalk.herokuapp.com/docs/{rel}","name":"doc","templated":true}],"doc:foo":{"href":"bar"},"self":{"href":"uri"}},"name":"Dummy"}`
 
 	ds := DummyStruct{"Dummy"}
 
 	r := NewResource(ds, "uri")
 	r.RegisterCurie("doc", "http://haltalk.herokuapp.com/docs/{rel}", true).AddNewLink("foo", "bar")
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given: %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestRegisterMultipleCuries(t *testing.T) {
+	expected := `{"_links":{"curies":[{"href":"http://haltalk.herokuapp.com/docs/{rel}","name":"doc","templated":true},{"href":"http://haltalk.herokuapp.com/abc/{rel}","name":"abc","templated":true}],"doc:foo":{"href":"bar"},"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	r.RegisterCurie("doc", "http://haltalk.herokuapp.com/docs/{rel}", true).AddNewLink("foo", "bar")
+	r.RegisterCurie("abc", "http://haltalk.herokuapp.com/abc/{rel}", true)
 
 	jr, err := json.Marshal(r)
 	if err != nil {

--- a/hal_test.go
+++ b/hal_test.go
@@ -155,9 +155,10 @@ func TestRegisterMultipleCuries(t *testing.T) {
 
 func TestResourceCuries(t *testing.T) {
 	ds := DummyStruct{"Dummy"}
+	curieName := "doc"
 
 	r := NewResource(ds, "uri")
-	curie := r.RegisterCurie("doc", "http://haltalk.herokuapp.com/docs/{rel}", true)
+	curie := r.RegisterCurie(curieName, "http://haltalk.herokuapp.com/docs/{rel}", true)
 
 	curie.AddNewLink("foo", "bar")
 	curies := r.Curies
@@ -166,11 +167,11 @@ func TestResourceCuries(t *testing.T) {
 		t.Errorf("Wrong number of CurieHandles returned from resource:\n - Given: %v\n- Expected: %v\n", len(curies), 1)
 	}
 
-	if curies[0].Resource != r {
+	if curies[curieName].Resource != r {
 		t.Errorf("CurieHandle.Resource does not reference owning resource")
 	}
 
-	if curie != curies[0] {
+	if curie != curies[curieName] {
 		t.Errorf("curieHandle returned by RegisterCurie() is not the same reference")
 	}
 

--- a/hal_test.go
+++ b/hal_test.go
@@ -101,6 +101,62 @@ func TestNewLink(t *testing.T) {
 	}
 }
 
+func TestNewLinkMultipleAttributes(t *testing.T) {
+	expected := `{"href":"http://haltalk.herokuapp.com/docs/{rel}","name":"doc","templated":true}`
+
+	l := NewLink("http://haltalk.herokuapp.com/docs/{rel}", LinkAttr{"name": "doc"}, LinkAttr{"templated": true})
+
+	jr, err := json.Marshal(l)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong link struct: %s\n- Given: %s\n- Expected: %s", l, jr, expected)
+	}
+}
+
+func TestRegisterCurie(t *testing.T) {
+	expected := `{"_links":{"curies":{"href":"http://haltalk.herokuapp.com/docs/{rel}","name":"doc","templated":true},"doc:foo":{"href":"bar"},"self":{"href":"uri"}},"name":"Dummy"}`
+
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	r.RegisterCurie("doc", "http://haltalk.herokuapp.com/docs/{rel}", true).AddNewLink("foo", "bar")
+
+	jr, err := json.Marshal(r)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	if string(jr) != expected {
+		t.Errorf("Wrong Resource struct: %s\n- Given: %s\n- Expected: %s", r, jr, expected)
+	}
+}
+
+func TestResourceCuries(t *testing.T) {
+	ds := DummyStruct{"Dummy"}
+
+	r := NewResource(ds, "uri")
+	curie := r.RegisterCurie("doc", "http://haltalk.herokuapp.com/docs/{rel}", true)
+
+	curie.AddNewLink("foo", "bar")
+	curies := r.Curies
+
+	if len(curies) != 1 {
+		t.Errorf("Wrong number of CurieHandles returned from resource:\n - Given: %v\n- Expected: %v\n", len(curies), 1)
+	}
+
+	if curies[0].Resource != r {
+		t.Errorf("CurieHandle.Resource does not reference owning resource")
+	}
+
+	if curie != curies[0] {
+		t.Errorf("curieHandle returned by RegisterCurie() is not the same reference")
+	}
+
+}
+
 func TestAddNewLink(t *testing.T) {
 	expected := `{"_links":{"foo":{"href":"bar"},"self":{"href":"uri"}},"name":"Dummy"}`
 


### PR DESCRIPTION
Hi. Thought I'd have a stab at adding Curies support to your excellent library. The RFC is a little vague on whether the curies should be a JSON array or not (it just describes the curies relations as a 'set') but the canonical examples seem to include it as an array, even if it's a single item. 